### PR TITLE
Count reorderings inversely

### DIFF
--- a/netemd/cmd.go
+++ b/netemd/cmd.go
@@ -8,8 +8,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/thomas-fossati/netem-pub/netemd/config"
-	"github.com/thomas-fossati/netem-pub/netemd/service"
+	"github.com/kollerz/netem-pub/netemd/config"
+	"github.com/kollerz/netem-pub/netemd/service"
 )
 
 var Verbose bool

--- a/netemd/service/service.go
+++ b/netemd/service/service.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/thomas-fossati/netem-pub/hping"
-	"github.com/thomas-fossati/netem-pub/netem"
-	"github.com/thomas-fossati/netem-pub/netemd/config"
+	"github.com/kollerz/netem-pub/hping"
+	"github.com/kollerz/netem-pub/netem"
+	"github.com/kollerz/netem-pub/netemd/config"
 )
 
 type ifaceExpVars struct {

--- a/netemd/service/service.go
+++ b/netemd/service/service.go
@@ -35,7 +35,7 @@ func updateNetemExpVars(iface config.Interface, d *netem.NetemData) {
 
 	v.PktCount.Set(d.Total)
 	v.PktDropped.Set(d.Dropped)
-	v.PktReordered.Set(d.Reordered)
+	v.PktReordered.Set(d.Total - d.Reordered)
 	v.BytesCount.Set(d.Bytes)
 }
 


### PR DESCRIPTION
The `netem` definition of `reorder 1% delay 10ms` is "send 1% of packets immediately, delay the other 99% 10ms". We would like `reorder 1% delay 10ms` to be defined as " send 99% of packets immediately, delay 1% by 10ms". As a shortcut, we'll use the inverse configuration `reorder 99% delay 10ms`, which requires to change the counting of reorderings. 